### PR TITLE
bower config to work out of the box

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,8 @@
   "version": "0.6.3b",
   "main": [
     "./annotorious.min.js",
-    "./css/annotorious.css"
+    "./css/annotorious.css",
+    "./images/*.png"
   ],
   "dependencies": {}
 }

--- a/bower.json
+++ b/bower.json
@@ -1,29 +1,26 @@
 {
-    "author": {
-        "name": "https://github.com/annotorious/annotorious/graphs/contributors"
-    },
-    "name": "annotorious-bower",
-    "keywords": [
-        "annotorious",
-        "image",
-        "annotation",
-		"web"
-    ],
-	 "ignore": [
-        "**/.*",
-        "node_modules",
-        "components"
-    ],
-    "license": "MIT",
-    "ignore": [],
-    "description": "Image Annotation for the Web - Annotorious Core Library",
-    "version": "0.6.3b",
-    "main": [
-		"./annotorious.min.js",
-		"./css/annotorious.css",
-        "./css/annotorious-dark.css"
-	],
-    "dependencies": {
-
-    }
+  "author": {
+    "name": "https://github.com/annotorious/annotorious/graphs/contributors"
+  },
+  "name": "annotorious-bower",
+  "keywords": [
+    "annotorious",
+    "image",
+    "annotation",
+    "web"
+  ],
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "components"
+  ],
+  "license": "MIT",
+  "ignore": [],
+  "description": "Image Annotation for the Web - Annotorious Core Library",
+  "version": "0.6.3b",
+  "main": [
+    "./annotorious.min.js",
+    "./css/annotorious.css"
+  ],
+  "dependencies": {}
 }


### PR DESCRIPTION
Modified the bower.json `main` block so that the dark theme is not included by default, and also added a glob to include all of the image files needed to render the UI.

To use the dark theme, use an override inside your project's bower.json to point to annotorious-dark.css instead of the default, and also include the theme-dark images. 
